### PR TITLE
Generate wheel for Cython 3.0.8

### DIFF
--- a/.github/workflows/cython.yml
+++ b/.github/workflows/cython.yml
@@ -5,7 +5,7 @@ on: [workflow_dispatch]
 # See https://github.com/cython/cython/blob/master/.github/workflows/wheels.yml
 
 env:
-  VERSION: 0.29.33
+  VERSION: 3.0.8
   CIBW_BUILD: nogil39-*
   CIBW_ARCHS_LINUX: auto
   CIBW_ARCHS_MACOS: universal2


### PR DESCRIPTION
In scikit-learn we are testing nogil and we recently updated our minimum supported Cython version to 3.0.8 in https://github.com/scikit-learn/scikit-learn/pull/28284.

Let's be optimist and update this action to see whether that works :crossed_fingers:!

